### PR TITLE
Add basic Async support

### DIFF
--- a/Timelog.md
+++ b/Timelog.md
@@ -1,0 +1,2 @@
+Project Core API
+================

--- a/src/BccCode.Linq/ApiClient/ApiPagedEnumerable.cs
+++ b/src/BccCode.Linq/ApiClient/ApiPagedEnumerable.cs
@@ -83,7 +83,7 @@ internal class ApiPagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IApi
         int page = 1;
         do
         {
-            pageData = await RequestPageAsync(page, cancellationToken);
+            pageData = await RequestPageAsync(page++, cancellationToken);
             if (pageData == null)
                 yield break;
 
@@ -100,7 +100,7 @@ internal class ApiPagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IApi
         int page = 1;
         do
         {
-            pageData = RequestPage(page);
+            pageData = RequestPage(page++);
             if (pageData == null)
                 yield break;
 

--- a/src/BccCode.Linq/Async/AsyncEnumerable.cs
+++ b/src/BccCode.Linq/Async/AsyncEnumerable.cs
@@ -1,0 +1,32 @@
+namespace BccCode.Linq.Async;
+
+/// <summary>
+/// Holding extension methods to <see cref="IAsyncEnumerable{T}"/>.
+/// </summary>
+internal static class AsyncEnumerable
+{
+    /// <summary>
+    /// Client side execution of Linq method <b>Select</b> with <see cref="IAsyncEnumerable{T}"/> as source. 
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException">
+    /// Is thrown when either <paramref name="source"/> or <paramref name="selector"/> is <c>null</c>.
+    /// </exception>
+    public static async IAsyncEnumerable<TResult> Select<TSource, TResult>(this IAsyncEnumerable<TSource> source,
+        Func<TSource, TResult> selector)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+        if (selector == null)
+            throw new ArgumentNullException(nameof(selector));
+
+        await foreach (var item in source)
+        {
+            yield return selector.Invoke(item);
+        }
+    }
+}

--- a/src/BccCode.Linq/Async/IAsyncQueryProvider.cs
+++ b/src/BccCode.Linq/Async/IAsyncQueryProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace BccCode.Linq.Async;
+
+/// <summary>
+/// Defines method to execute queries asynchronously that are described by an IQueryable object.
+/// </summary>
+/// <remarks>
+/// This is a clone of
+/// <a href="https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.query.iasyncqueryprovider?view=efcore-7.0">
+/// Microsoft.EntityFrameworkCore.Query.IAsyncQueryProvider</a>
+/// </remarks>
+public interface IAsyncQueryProvider : IQueryProvider
+{
+    public TResult ExecuteAsync<TResult> (System.Linq.Expressions.Expression expression, CancellationToken cancellationToken = default);
+}

--- a/src/BccCode.Linq/Async/IAsyncQueryProvider.cs
+++ b/src/BccCode.Linq/Async/IAsyncQueryProvider.cs
@@ -10,5 +10,5 @@
 /// </remarks>
 public interface IAsyncQueryProvider : IQueryProvider
 {
-    public TResult ExecuteAsync<TResult> (System.Linq.Expressions.Expression expression, CancellationToken cancellationToken = default);
+    public TResult ExecuteAsync<TResult>(System.Linq.Expressions.Expression expression, CancellationToken cancellationToken = default);
 }

--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -1,0 +1,143 @@
+﻿namespace BccCode.Linq.Async;
+
+/// <summary>
+/// Adds extension methods to run async. operations against a instance of <see cref="IQueryable{T}"/>. 
+/// </summary>
+public static class QueryableAsyncExtensions
+{
+    /// <summary>
+    /// Processes the expression tree behind <paramref name="queryable"/> object and returns
+    /// a <see cref="IAsyncEnumerator{T}"/> object for further async calls. 
+    /// </summary>
+    /// <remarks>
+    /// The whole expression tree is parsed. When the expression tree contains logic which cannot be
+    /// handled by the <see cref="IAsyncQueryProvider" /> (e.g. you pass a join to a API endpoint provider),
+    /// an exception <see cref="InvalidOperationException"/> is thrown. Try to simplify your query or use
+    /// <see cref="ToListAsync{TSource}"/> prior calling advanced Linq logic which the provider cannot handle.
+    /// </remarks>
+    /// <param name="queryable">
+    /// The queryable object which shall be casted. The provider of the queryable object must implement
+    /// <see cref="IAsyncQueryProvider" />.
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="queryable"/>.</typeparam>
+    /// <returns></returns>
+    /// <example>
+    /// Example using <b>AsAsyncEnumerable</b>:
+    /// <code>
+    /// await foreach(var item in query.AsAsyncEnumerable())
+    /// {
+    ///     // Processing of item here ...
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="ArgumentNullException">
+    /// Is thrown when <paramref name="queryable"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Is thrown when the Provider of <paramref name="queryable"/> does not implement <see cref="IAsyncQueryProvider"/>.
+    /// </exception>
+    public static IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(this IQueryable<TSource> queryable, CancellationToken cancellationToken = default)
+    {
+        if (queryable == null)
+            throw new ArgumentNullException(nameof(queryable));
+
+        if (queryable.Provider is not IAsyncQueryProvider asyncQueryProvider)
+            throw new ArgumentException(
+                $"The Provider behind the query must implement {typeof(IAsyncQueryProvider).FullName}",
+                nameof(queryable));
+
+        return asyncQueryProvider.ExecuteAsync<IAsyncEnumerable<TSource>>(queryable.Expression, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="List{T}"/> from an <see cref="IQueryable{T}"/> which has a Provider implementing <see cref="IAsyncQueryProvider"/>.
+    /// </summary>
+    /// <param name="source">
+    /// The <see cref="IQueryable{T}"/> to create a <see cref="List{T}"/> from.
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <returns>
+    /// A <see cref="List{T}"/> that contains elements from the input sequence.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    public static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        var list = new List<TSource>();
+
+        await foreach (var item in source.AsAsyncEnumerable(cancellationToken))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Returns the first element of a sequence.
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The source sequence is empty.
+    /// </exception>
+    public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        var asyncEnumerable = source.AsAsyncEnumerable(cancellationToken);
+
+        var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+        
+        if (await enumerator.MoveNextAsync())
+        {
+            return enumerator.Current;
+        }
+        else
+        {
+            throw new InvalidOperationException("The source sequence is empty.");
+        }
+    }
+
+    /// <summary>
+    /// Returns the first element of a sequence, or a default value if the sequence contains no elements.
+    /// </summary>
+    /// <param name="source">The <see cref="IQueryable{T}"/> to return the first element of.</param>
+    /// <param name="cancellationToken">The type of the elements of <paramref name="source"/></param>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+    /// <returns>
+    /// <c>default</c>(<typeparamref name="TSource"/>) if <paramref name="source"/> is empty; otherwise, the first element in <paramref name="source"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    public static async Task<TSource?> FirstOrDefault<TSource>(this IQueryable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        var asyncEnumerable = source.AsAsyncEnumerable(cancellationToken);
+
+        var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+
+        if (await enumerator.MoveNextAsync())
+        {
+            return enumerator.Current;
+        }
+
+        return default(TSource);
+    }
+}

--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -100,7 +100,7 @@ public static class QueryableAsyncExtensions
         var asyncEnumerable = source.Take(1).AsAsyncEnumerable(cancellationToken);
 
         var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
-        
+
         if (await enumerator.MoveNextAsync())
         {
             return enumerator.Current;

--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -97,7 +97,7 @@ public static class QueryableAsyncExtensions
         if (source == null)
             throw new ArgumentNullException(nameof(source));
 
-        var asyncEnumerable = source.AsAsyncEnumerable(cancellationToken);
+        var asyncEnumerable = source.Take(1).AsAsyncEnumerable(cancellationToken);
 
         var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
         
@@ -129,7 +129,7 @@ public static class QueryableAsyncExtensions
         if (source == null)
             throw new ArgumentNullException(nameof(source));
 
-        var asyncEnumerable = source.AsAsyncEnumerable(cancellationToken);
+        var asyncEnumerable = source.Take(1).AsAsyncEnumerable(cancellationToken);
 
         var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
 

--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace BccCode.Linq.Async;
 
 /// <summary>
-/// Adds extension methods to run async. operations against a instance of <see cref="IQueryable{T}"/>. 
+/// Adds extension methods to run async. operations against an instance of <see cref="IQueryable{T}"/>. 
 /// </summary>
 public static class QueryableAsyncExtensions
 {

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -148,10 +148,10 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
         return lambdaFunc.Invoke();
     }
 
-    public TResult Execute<TResult>(Expression expression)
+    public TResult? Execute<TResult>(Expression expression)
     {
         object result = ((IQueryProvider)this).Execute(expression);
-        return (TResult)result;
+        return result == null ? default : (TResult)result;
     }
 
     #endregion

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -60,13 +60,13 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
         /// The queryable should return a <see cref="IEnumerable{T}"/>.
         /// </summary>
         Enumerable,
-        
+
         /// <summary>
         /// The queryable should return a <see cref="IAsyncEnumerable{T}"/>.
         /// </summary>
         AsyncEnumerable
     }
-    
+
     /// <summary>
     /// A provider class cannot handle multiple executions at the same time.
     ///
@@ -110,7 +110,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
     }
 
     #region IQueryProvider
-    
+
     public IQueryable CreateQuery(Expression expression)
     {
         Type? elementType = TypeHelper.GetElementType(expression.Type);
@@ -155,7 +155,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
     }
 
     #endregion
-    
+
     #region IAsyncQueryProvider
 
     public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default)

--- a/src/BccCode.Linq/QueryProvider/QueryableExtensions.cs
+++ b/src/BccCode.Linq/QueryProvider/QueryableExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq.Expressions;
+
+namespace BccCode.Linq;
+
+/// <summary>
+/// Adds extension methods for <see cref="IQueryable{T}"/> to specify advanced behavior not covered
+/// by default C# Linq. 
+/// </summary>
+public static class QueryableExtensions
+{
+    [Obsolete("Not implemented yet", true)]
+    public static IQueryable<TEntity> Include<TEntity, TProperty>(
+        this IQueryable<TEntity> source,
+        Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -148,7 +148,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(2, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void WhereIntGreaterThanAsyncTest()
     {
@@ -192,7 +192,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(2, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void WhereIntNotGreaterThanAsyncTest()
     {
@@ -240,7 +240,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(1, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
     public async void WhereSelectAndAsyncTest()
     {
@@ -294,7 +294,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(3, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
     public async void WhereSelectOrAsyncTest()
     {
@@ -349,7 +349,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(4, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
     public async void WhereSelectOrTwiceAsyncTest()
     {
@@ -401,7 +401,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(1, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void StringStartsWithAsyncTest()
     {
@@ -449,7 +449,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(1, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void WhereStringEndsWithAsyncTest()
     {
@@ -497,7 +497,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(0, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void WhereStringIsNullOrEmptyAsyncTest()
     {
@@ -545,7 +545,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(2, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void WhereNestedEqualAsyncTest()
     {
@@ -592,7 +592,7 @@ public class LinqQueryProviderTests
         Assert.Null(api.LastRequest?.Limit);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void OrderByAsyncTest()
     {
@@ -630,7 +630,7 @@ public class LinqQueryProviderTests
         Assert.Null(api.LastRequest?.Limit);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void OrderByDescendingAsyncTest()
     {
@@ -668,7 +668,7 @@ public class LinqQueryProviderTests
         Assert.Null(api.LastRequest?.Limit);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void OrderByMultipleColumnsAsyncTest()
     {
@@ -774,7 +774,7 @@ public class LinqQueryProviderTests
         //Assert.Equal(3, persons.Count);
         Assert.Equal(5, persons.Count);
     }
-    
+
     [Fact]
     public async void OrderByNestingAsyncTest()
     {

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -241,7 +241,7 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
     
-    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/26")]
+    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
     public async void WhereSelectAndAsyncTest()
     {
         var api = new ApiClientMockup();
@@ -295,7 +295,7 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
     
-    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/26")]
+    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
     public async void WhereSelectOrAsyncTest()
     {
         var api = new ApiClientMockup();
@@ -350,7 +350,7 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
     
-    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/26")]
+    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
     public async void WhereSelectOrTwiceAsyncTest()
     {
         var api = new ApiClientMockup();

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -241,7 +241,7 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
 
-    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
+    [Fact]
     public async void WhereSelectAndAsyncTest()
     {
         var api = new ApiClientMockup();
@@ -295,7 +295,7 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
 
-    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
+    [Fact]
     public async void WhereSelectOrAsyncTest()
     {
         var api = new ApiClientMockup();
@@ -350,7 +350,7 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
 
-    [Fact(Skip = "Does not work, see https://github.com/bcc-code/rule-filter-parser-dotnet/issues/29")]
+    [Fact]
     public async void WhereSelectOrTwiceAsyncTest()
     {
         var api = new ApiClientMockup();

--- a/tests/BccCode.Linq.Tests/Mockups/ApiClientMockupBase.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiClientMockupBase.cs
@@ -80,7 +80,9 @@ public class ApiClientMockupBase : IApiClient
         LastEndpoint = endpoint;
         LastRequest = request;
 
-        return Task.FromResult<TResult?>(null);
+        return Task.FromResult(
+            Get<TResult>(endpoint, request)
+        );
     }
 
     IApiRequest IApiClient.ConstructApiRequest(string path)


### PR DESCRIPTION
This PR implements basic Async support (#29), including some namespace refactoring:

* multiple Async extension methods like `ToListAsync`, `AsAsyncEnumerable` are implement (see `QueryableAsyncExtensions`). These are put into a separate namespace `RuleFilterParser.Linq.Async` because you might want to use other libraries performing the async. operations (like [Microsoft.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/7.0.5) or [System.Linq.Async](https://www.nuget.org/packages/System.Linq.Async)) and C# would not know which extension method to use when you include both namesapce in the same project.
* interface `IAsyncQueryProvider` is now officially implemented (is a copy of the logic from EF Core)
* all API client logic is now moved to interface `RuleFilterParser.ApiClient`


### Open issue with Select (Selector for Async not implemented)

When running an async. call against the API, it requires that the whole expression tree can be parsed. Currently the linq `Select` operation is invoced locally (see issue #26 as well) which means you cannot (yet) use async. linq for select operations.

For example, this code will fail:

``` csharp
var query = api.Persons.Select(p => new { p.Name });

await foreach (var item in query.AsAsyncEnumerable())
{ /* ... */ }
```

but this code will work:

``` csharp
var query = api.Persons.Where(p => p.Name.StartsWith("Max"));

await foreach (var item in query.AsAsyncEnumerable())
{ /* ... */ }
```

This should be IMO be part of a new PR because it affects multiple parts and needs a bit rethinking.