### PR TITLE
enquote nuget env. API_KEY

### DIFF
--- a/.github/workflows/nuget-package-publish.yml
+++ b/.github/workflows/nuget-package-publish.yml
@@ -49,5 +49,5 @@ jobs:
         run: dotnet pack -p:PackageVersion=${{ env.VERSION }} -c Release -o . ${{ env.CSPROJ_PATH }}
 
       - name: Publish
-        run: dotnet nuget push *.nupkg -k ${{ env.API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push *.nupkg -k "${{ env.API_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
         


### PR DESCRIPTION
It is better to enquote the API key in case it is not there, e.g. when running it on a fork, there will be no API key and you get a strange error message.