### PR TITLE
skip Publish on forks (= where API_KEY is not given)

### DIFF
--- a/.github/workflows/nuget-package-publish.yml
+++ b/.github/workflows/nuget-package-publish.yml
@@ -49,5 +49,5 @@ jobs:
         run: dotnet pack -p:PackageVersion=${{ env.VERSION }} -c Release -o . ${{ env.CSPROJ_PATH }}
 
       - name: Publish
+        if: env.API_KEY != ''
         run: dotnet nuget push *.nupkg -k "${{ env.API_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
-        


### PR DESCRIPTION
This should fix the failing CI in #32:

We skip publishing the NuGet packages when environment variable API_KEY is not given (e.g. on forks)